### PR TITLE
Change the interpreter line to '/usr/bin/env python2'

### DIFF
--- a/xstrings.py
+++ b/xstrings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 '''
 xstrings - print the strings of encoded printable characters in files.


### PR DESCRIPTION
When both python3 and python2 are installed, the command 'python' is for python3. 
